### PR TITLE
Grab ACCESS_TOKEN from envvar

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         distro:
-          - centos8
+#          - centos8
 #          - ubuntu1804
           - ubuntu2004
 #          - ubuntu2204

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         distro:
-          - centos8
-          - ubuntu1804
+#          - centos8
+#          - ubuntu1804
           - ubuntu2004
 #          - ubuntu2204
           - debian10
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule[docker] docker
+        run: pip3 install ansible molecule-plugins[docker] docker
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         distro:
           - centos8
-          - ubuntu1804
+#          - ubuntu1804
           - ubuntu2004
 #          - ubuntu2204
           - debian10

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Motley-cue Role
 
-This ansible role installs the [motley-cue](https://motley-cue.readthedocs.io/en/latest/) software.  
+This ansible role installs the [motley-cue](https://motley-cue.readthedocs.io/) software.
 The github repository of the motley-cue is [here](https://github.com/dianagudu/motley_cue).
 
 ## Example Playbook
@@ -14,6 +14,13 @@ This an example of how to install this role:
       roles:
       - { role: 'grycap.motley-cue', ssh_oidc_my_vo: true, ssh_oidc_other_vos: 'vo_name' }
 
+And then execute it with:
+
+    ansible-playbook --extra-vars ACCESS_TOKEN=$(oidc-token <account>) playbook.yaml
+
+To get the `oidc-token` command working please check [ssh-oidc](https://github.com/EOSC-synergy/ssh-oidc)
+
 # Contributing to the role
-In order to keep the code clean, pushing changes to the master branch has been disabled. If you want to contribute, you have to create a branch, upload your changes and then create a pull request.  
+
+In order to keep the code clean, pushing changes to the master branch has been disabled. If you want to contribute, you have to create a branch, upload your changes and then create a pull request.
 Thanks

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -6,5 +6,5 @@
 
 - name: Add apt KIT repository debian
   apt_repository:
-    repo: deb [signed-by=/etc/apt/trusted.gpg.d/kitrepo-archive.asc] https://repo.data.kit.edu/debian/{{ansible_distribution_version}} ./
+    repo: deb [signed-by=/etc/apt/trusted.gpg.d/kitrepo-archive.asc] https://repo.data.kit.edu/debian/{{ansible_distribution_major_version}} ./
     state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,13 +88,23 @@
       line: '#!/usr/bin/python3.8'
   when: ansible_distribution == "Ubuntu" and ansible_distribution_major_version == "18"
 
+- name: Set access token with IM for contextualise_ssh_server
+  set_fact:
+    OIDC_ACCESS_TOKEN: "{{ IM_INFRASTRUCTURE_AUTH }}"
+  when: IM_INFRASTRUCTURE_AUTH is defined and IM_INFRASTRUCTURE_AUTH is not search(":")
+
+- name: Set access token as extra-var for contextualise_ssh_server
+  set_fact:
+    OIDC_ACCESS_TOKEN: "{{ ACCESS_TOKEN }}"
+  when: ACCESS_TOKEN is defined
+
 - name: Execute contextualise_ssh_server command
-  command: contextualise_ssh_server {{IM_INFRASTRUCTURE_AUTH}}
+  command: contextualise_ssh_server {{OIDC_ACCESS_TOKEN}}
   args:
     chdir: /opt/motley_cue
     creates: /opt/motley_cue/motley_cue.conf
-  when: IM_INFRASTRUCTURE_AUTH is defined and IM_INFRASTRUCTURE_AUTH is not search(":")
   register: contextualise_ssh_server
+  when: OIDC_ACCESS_TOKEN is defined
   environment: "{{command_env}}"
 
 - name: Copy conf files to /etc


### PR DESCRIPTION

Hi,

Currently this role only contextualizes the VM correctly when used via IM (see dependency with `IM_INFRASTRUCTURE_AUTH`):

https://github.com/grycap/ansible-role-motley-cue/blob/ebc7ef040fb0cbbb7210171669dcd9a72f960cbc/tasks/main.yml#L91-L98

However, it would also be interesting to use this role out of IM, for example running it with:

```bash
ansible-playbook --extra-vars ACCESS_TOKEN=$(oidc-token <account>) playbook.yaml
```

This PR adds the changes to make it happen.

Please have a look and let me know your thoughts.

Best regards,
Sebastian