### PR TITLE
Generalize the building of eduPersonEntitlement

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,9 @@
 ssh_oidc_my_vo: false
-ssh_oidc_other_vos: ''
+ssh_oidc_other_vos_namespace: urn:mace:egi.eu
+ssh_oidc_other_vos_name: ''
+ssh_oidc_other_vos_groups: ''
+#example:
+#ssh_oidc_other_vos_groups:
+#- my.group
+ssh_oidc_other_vos_role: member
+ssh_oidc_other_vos_gropu_authority: aai.egi.eu

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,4 +6,4 @@ ssh_oidc_other_vos_groups: ''
 #ssh_oidc_other_vos_groups:
 #- my.group
 ssh_oidc_other_vos_role: member
-ssh_oidc_other_vos_gropu_authority: aai.egi.eu
+ssh_oidc_other_vos_authority: aai.egi.eu

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -25,6 +25,8 @@
     - name: "Include grycap.motley-cue"
       include_role:
         name: "ansible-role-motley-cue"
+      vars:
+        ssh_oidc_other_vos_name: "vo.test.eu"
 
 
 #    - slurp: src=/etc/docker/daemon.json

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,10 +76,31 @@
     command_env: "{{ command_env | combine ({ 'SSH_AUTHORISE_OTHERS_IN_MY_VO' : 1 }) }}"
   when: ssh_oidc_my_vo
 
+# Refernce:
+# https://docs.egi.eu/users/aai/check-in/vos/expressing-vo-information/
+- name: set eduPersonEntitlement
+  set_fact:
+    eduPersonEntitlement: >-
+      {{ssh_oidc_other_vos_namespace}}
+      :group
+      :{{ssh_oidc_other_vos_name}}
+      {%for group in ssh_oidc_other_vos_groups %}
+      :{{group}}
+      {% endfor %}
+      {% if ssh_oidc_other_vos_role != '' %}
+      :role={{ssh_oidc_other_vos_role}}
+      {% endif %}
+      #{{ssh_oidc_other_vos_gropu_authority}}
+
+- name: Clean up and show eduPersonEntitlement that will be used
+  debug:
+    msg: "{{ eduPersonEntitlement | replace(' ','') }}"
+  register: eduPersonEntitlement_trimmed
+
 - name: set SSH_AUTHORISE_VOS
   set_fact:
-    command_env: "{{ command_env | combine ({ 'SSH_AUTHORISE_VOS' : ['urn:mace:egi.eu:group:{{ssh_oidc_other_vos}}:role=member#aai.egi.eu'] }) }}"
-  when: ssh_oidc_other_vos != ''
+    command_env: "{{ command_env | combine ({ 'SSH_AUTHORISE_VOS' : ['{{ eduPersonEntitlement_trimmed.msg }}'] }) }}"
+  when: ssh_oidc_other_vos_name != ''
 
 - name: Use python3.8 in Ubuntu 18.08
   lineinfile:
@@ -102,7 +123,6 @@
   command: contextualise_ssh_server {{OIDC_ACCESS_TOKEN}}
   args:
     chdir: /opt/motley_cue
-    creates: /opt/motley_cue/motley_cue.conf
   register: contextualise_ssh_server
   when: OIDC_ACCESS_TOKEN is defined
   environment: "{{command_env}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,7 +90,7 @@
       {% if ssh_oidc_other_vos_role != '' %}
       :role={{ssh_oidc_other_vos_role}}
       {% endif %}
-      #{{ssh_oidc_other_vos_gropu_authority}}
+      #{{ssh_oidc_other_vos_authority}}
 
 - name: Clean up and show eduPersonEntitlement that will be used
   debug:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,30 +76,33 @@
     command_env: "{{ command_env | combine ({ 'SSH_AUTHORISE_OTHERS_IN_MY_VO' : 1 }) }}"
   when: ssh_oidc_my_vo
 
-# Refernce:
-# https://docs.egi.eu/users/aai/check-in/vos/expressing-vo-information/
-- name: set eduPersonEntitlement
-  set_fact:
-    eduPersonEntitlement: >-
-      {{ssh_oidc_other_vos_namespace}}
-      :group
-      :{{ssh_oidc_other_vos_name}}
-      {%for group in ssh_oidc_other_vos_groups %}
-      :{{group}}
-      {% endfor %}
-      {% if ssh_oidc_other_vos_role != '' %}
-      :role={{ssh_oidc_other_vos_role}}
-      {% endif %}
-      #{{ssh_oidc_other_vos_authority}}
+- block:
 
-- name: Clean up and show eduPersonEntitlement that will be used
-  debug:
-    msg: "{{ eduPersonEntitlement | replace(' ','') }}"
-  register: eduPersonEntitlement_trimmed
+  # Refernce:
+  # https://docs.egi.eu/users/aai/check-in/vos/expressing-vo-information/
+  - name: set eduPersonEntitlement
+    set_fact:
+      eduPersonEntitlement: >-
+        {{ssh_oidc_other_vos_namespace}}
+        :group
+        :{{ssh_oidc_other_vos_name}}
+        {%for group in ssh_oidc_other_vos_groups %}
+        :{{group}}
+        {% endfor %}
+        {% if ssh_oidc_other_vos_role != '' %}
+        :role={{ssh_oidc_other_vos_role}}
+        {% endif %}
+        #{{ssh_oidc_other_vos_authority}}
 
-- name: set SSH_AUTHORISE_VOS
-  set_fact:
-    command_env: "{{ command_env | combine ({ 'SSH_AUTHORISE_VOS' : ['{{ eduPersonEntitlement_trimmed.msg }}'] }) }}"
+  - name: Clean up and show eduPersonEntitlement that will be used
+    debug:
+      msg: "{{ eduPersonEntitlement | replace(' ','') }}"
+    register: eduPersonEntitlement_trimmed
+
+  - name: set SSH_AUTHORISE_VOS
+    set_fact:
+      command_env: "{{ command_env | combine ({ 'SSH_AUTHORISE_VOS' : ['{{ eduPersonEntitlement_trimmed.msg }}'] }) }}"
+
   when: ssh_oidc_other_vos_name != ''
 
 - name: Use python3.8 in Ubuntu 18.08


### PR DESCRIPTION

At the moment, the construction of the `eduPersonEntitlement` is mostly harcoded:
https://github.com/grycap/ansible-role-motley-cue/blob/950d21af0724550dc17dd8019165ca2a4e2a7b93/tasks/main.yml#L79-L82

This PR adds the changes required to make it configurable with Ansible variables.

Additionally, the `creates` argument when executing `contextualise_ssh_server` has been deleted:
https://github.com/grycap/ansible-role-motley-cue/blob/950d21af0724550dc17dd8019165ca2a4e2a7b93/tasks/main.yml#L105

Otherwise, updating the value of the variables for the configuration of the VO won't be applied to `motley_cue.conf` after it has been created for the first time.

Instead of `ssh_oidc_other_vos_*` variables, we may also want to consider a shorter option for the naming.